### PR TITLE
Remove unsupported MARS option from SQL connection string

### DIFF
--- a/src/Talonario.Api.Server.Api/appsettings.json
+++ b/src/Talonario.Api.Server.Api/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "AutenticadorDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=autenticador;Persist Security Info=True;User ID=userdetrannetatelier;Password=detranR03334###$;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultipleActiveResultSets=True;",
-    "AtelierDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=dbDetranNetAtelier;Persist Security Info=True;User ID=UserApiCore;Password=detranR03332###@;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultipleActiveResultSets=True;"
+    "AutenticadorDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=autenticador;Persist Security Info=True;User ID=userdetrannetatelier;Password=detranR03334###$;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;",
+    "AtelierDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=dbDetranNetAtelier;Persist Security Info=True;User ID=UserApiCore;Password=detranR03332###@;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;"
   },
   "Jwt": {
     "SecurityKey": "NlMzMGtjYVIzVWl5YnFhc3pNUVU4QT09",


### PR DESCRIPTION
## Summary
- remove the MultipleActiveResultSets flag from both configured SQL Server connection strings so the provider no longer raises a compatibility error

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ce21e86c8326aa024681c20de370