### PR TITLE
Prevent NRE when termo details are missing

### DIFF
--- a/src/Talonario.Api.Server.Application/TermoService.cs
+++ b/src/Talonario.Api.Server.Application/TermoService.cs
@@ -55,6 +55,8 @@ namespace Talonario.Api.Server.Application
                 if (termoInput.aplicadoPorMatricula.Length > 8)
                     termoInput.aplicadoPorMatricula = termoInput.aplicadoPorMatricula.Substring(0, 8);
 
+                termoInput.termoConstatacao ??= new TermoConstatacaoDetalhesDto();
+
                 termoInput.termoConstatacao.matriculaTestemunha1 = ValidarCpfOuMatricula(termoInput.termoConstatacao?.matriculaTestemunha1);
                 termoInput.termoConstatacao.matriculaTestemunha2 = ValidarCpfOuMatricula(termoInput.termoConstatacao?.matriculaTestemunha2);
 


### PR DESCRIPTION
## Summary
- instantiate the termoConstatacao details object when it is absent in the mobile payload to avoid null dereferences
- keep witness matricula normalization working even when no nested details were sent

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ce81e988832693cd887faefbb7e8