### PR TITLE
Enable MARS in database connection strings

### DIFF
--- a/src/Talonario.Api.Server.Api/appsettings.json
+++ b/src/Talonario.Api.Server.Api/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "AutenticadorDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=autenticador;Persist Security Info=True;User ID=userdetrannetatelier;Password=detranR03334###$;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;",
-    "AtelierDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=dbDetranNetAtelier;Persist Security Info=True;User ID=UserApiCore;Password=detranR03332###@;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;"
+    "AutenticadorDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=autenticador;Persist Security Info=True;User ID=userdetrannetatelier;Password=detranR03334###$;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultipleActiveResultSets=True;",
+    "AtelierDataBase": "Data Source=10.30.3.60,1433;Initial Catalog=dbDetranNetAtelier;Persist Security Info=True;User ID=UserApiCore;Password=detranR03332###@;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;MultipleActiveResultSets=True;"
   },
   "Jwt": {
     "SecurityKey": "NlMzMGtjYVIzVWl5YnFhc3pNUVU4QT09",


### PR DESCRIPTION
## Summary
- enable MultipleActiveResultSets for Autenticador and Atelier SQL connection strings to support concurrent data readers

## Testing
- `dotnet test` *(fails: `command not found: dotnet` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cf9fa2808326828e43a967af2e39