### PR TITLE
Atualiza fluxo de infracao nao transmitida

### DIFF
--- a/TalonarioTests/ApplicationTests/InfracaoApplicationServiceTests.cs
+++ b/TalonarioTests/ApplicationTests/InfracaoApplicationServiceTests.cs
@@ -1,0 +1,78 @@
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Talonario.Api.Server.Application;
+using Talonario.Api.Server.Application.Interfaces.Repositories;
+using Talonario.Api.Server.Application.ViewModels;
+using Xunit;
+
+namespace TalonarioTests.ApplicationTests
+{
+    public class InfracaoApplicationServiceTests
+    {
+        [Fact]
+        public async Task InserirInfracaoNaoTransmitida_AtualizaRegistroExistente_RetornaLinhasAfetadas()
+        {
+            // Arrange
+            var infracaoRepositoryMock = new Mock<IInfracaoRepository>();
+            infracaoRepositoryMock
+                .Setup(repository => repository.AtualizarInfracaoNaoTransmitidaAsync(It.IsAny<InfracaoNaoTransmitidaViewModel>()))
+                .ReturnsAsync(1);
+
+            var service = new InfracaoApplicationService(infracaoRepositoryMock.Object);
+
+            var infracaoNaoTransmitida = new InfracaoNaoTransmitidaViewModel(
+                0,
+                "AIT1234567",
+                "{}",
+                "veiculo",
+                null,
+                null,
+                "SUCESSO",
+                DateTime.UtcNow);
+
+            // Act
+            var resultado = await service.InserirInfracaoNaoTransmitida(infracaoNaoTransmitida);
+
+            // Assert
+            Assert.Equal(1, resultado);
+            infracaoRepositoryMock.Verify(
+                repository => repository.InserirInfracaoNaoTransmitida(It.IsAny<InfracaoNaoTransmitidaViewModel>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task InserirInfracaoNaoTransmitida_InsereQuandoRegistroInexistente_RetornaIdInserido()
+        {
+            // Arrange
+            var infracaoRepositoryMock = new Mock<IInfracaoRepository>();
+            infracaoRepositoryMock
+                .Setup(repository => repository.AtualizarInfracaoNaoTransmitidaAsync(It.IsAny<InfracaoNaoTransmitidaViewModel>()))
+                .ReturnsAsync(0);
+            infracaoRepositoryMock
+                .Setup(repository => repository.InserirInfracaoNaoTransmitida(It.IsAny<InfracaoNaoTransmitidaViewModel>()))
+                .ReturnsAsync(42);
+
+            var service = new InfracaoApplicationService(infracaoRepositoryMock.Object);
+
+            var infracaoNaoTransmitida = new InfracaoNaoTransmitidaViewModel(
+                0,
+                "AIT1234567",
+                "{}",
+                "veiculo",
+                null,
+                null,
+                "ERRO",
+                DateTime.UtcNow);
+
+            // Act
+            var resultado = await service.InserirInfracaoNaoTransmitida(infracaoNaoTransmitida);
+
+            // Assert
+            Assert.Equal(42, resultado);
+            infracaoRepositoryMock.Verify(
+                repository => repository.InserirInfracaoNaoTransmitida(It.IsAny<InfracaoNaoTransmitidaViewModel>()),
+                Times.Once);
+        }
+    }
+}

--- a/src/Talonario.Api.Server.Application/Entities/InfracaoNaoTransmitidaEntity.cs
+++ b/src/Talonario.Api.Server.Application/Entities/InfracaoNaoTransmitidaEntity.cs
@@ -18,7 +18,9 @@ namespace Talonario.Api.Server.Application.Entities
             string json,
             string tipo,
             DateTime? dataCancelamento,
-            DateTime? dataEnviado
+            DateTime? dataEnviado,
+            string motivoProcessamento = null,
+            DateTime? dataInclusao = null
         )
         {
             Id = id;
@@ -27,6 +29,8 @@ namespace Talonario.Api.Server.Application.Entities
             Tipo = tipo;
             DataCancelamento = dataCancelamento;
             DataEnviado = dataEnviado;
+            MotivoProcessamento = motivoProcessamento;
+            DataInclusao = dataInclusao;
         }
 
         #endregion Public Constructors
@@ -44,6 +48,10 @@ namespace Talonario.Api.Server.Application.Entities
         public string JSON { get; set; }
 
         public string Tipo { get; set; }
+
+        public string MotivoProcessamento { get; set; }
+
+        public DateTime? DataInclusao { get; set; }
 
         #endregion Public Properties
     }

--- a/src/Talonario.Api.Server.Application/InfracaoApplicationService.cs
+++ b/src/Talonario.Api.Server.Application/InfracaoApplicationService.cs
@@ -248,7 +248,10 @@ namespace Talonario.Api.Server.Application
         {
             infracaoNaoTransmitida.AIT = infracaoNaoTransmitida.AIT.Trim();
 
-            await _infracaoRepository.RemoverInfracaoNaoTransmitidaPorAIT(infracaoNaoTransmitida.AIT);
+            var linhasAtualizadas = await _infracaoRepository.AtualizarInfracaoNaoTransmitidaAsync(infracaoNaoTransmitida);
+
+            if (linhasAtualizadas > 0)
+                return linhasAtualizadas;
 
             var idInfracaoInserida = await _infracaoRepository.InserirInfracaoNaoTransmitida(infracaoNaoTransmitida);
             return idInfracaoInserida;

--- a/src/Talonario.Api.Server.Application/Interfaces/Repositories/IInfracaoRepository.cs
+++ b/src/Talonario.Api.Server.Application/Interfaces/Repositories/IInfracaoRepository.cs
@@ -53,7 +53,7 @@ namespace Talonario.Api.Server.Application.Interfaces.Repositories
 
         Task<bool> RemoverInfracaoAnexo(string ait);
 
-        Task<bool> RemoverInfracaoNaoTransmitidaPorAIT(string ait);
+        Task<int> AtualizarInfracaoNaoTransmitidaAsync(InfracaoNaoTransmitidaViewModel infracaoNaoTransmitida);
 
         Task<bool> RemoverInfracaoPdf(string ait);
 

--- a/src/Talonario.Api.Server.Application/Mappers/InfracaoNaoTransmitidaViewModelMapper.cs
+++ b/src/Talonario.Api.Server.Application/Mappers/InfracaoNaoTransmitidaViewModelMapper.cs
@@ -15,7 +15,9 @@ namespace Talonario.Api.Server.Application.Mappers
                 infracaoNaoTransmitidaEntity.JSON,
                 infracaoNaoTransmitidaEntity.Tipo == null ? "veiculo" : infracaoNaoTransmitidaEntity.Tipo,
                 infracaoNaoTransmitidaEntity.DataCancelamento,
-                infracaoNaoTransmitidaEntity.DataEnviado
+                infracaoNaoTransmitidaEntity.DataEnviado,
+                infracaoNaoTransmitidaEntity.MotivoProcessamento,
+                infracaoNaoTransmitidaEntity.DataInclusao
             );
         }
 

--- a/src/Talonario.Api.Server.Application/ViewModels/InfracaoNaoTransmitidaViewModel.cs
+++ b/src/Talonario.Api.Server.Application/ViewModels/InfracaoNaoTransmitidaViewModel.cs
@@ -12,7 +12,9 @@ namespace Talonario.Api.Server.Application.ViewModels
             string json,
             string tipo,
             DateTime? dataCancelamento,
-            DateTime? dataEnviado
+            DateTime? dataEnviado,
+            string motivoProcessamento = null,
+            DateTime? dataInclusao = null
         )
         {
             Id = id;
@@ -21,6 +23,8 @@ namespace Talonario.Api.Server.Application.ViewModels
             Tipo = tipo;
             DataCancelamento = dataCancelamento;
             DataEnviado = dataEnviado;
+            MotivoProcessamento = motivoProcessamento;
+            DataInclusao = dataInclusao;
         }
 
         #endregion Public Constructors
@@ -38,6 +42,10 @@ namespace Talonario.Api.Server.Application.ViewModels
         public string JSON { get; set; }
 
         public string Tipo { get; set; }
+
+        public string MotivoProcessamento { get; set; }
+
+        public DateTime? DataInclusao { get; set; }
 
         #endregion Public Properties
     }

--- a/src/Talonario.Api.Server.InfraStructure/Repository/InfracaoRepository.cs
+++ b/src/Talonario.Api.Server.InfraStructure/Repository/InfracaoRepository.cs
@@ -526,7 +526,9 @@ namespace Talonario.Api.Server.InfraStructure.Repository
                             JSON,
                             Tipo,
                             DataCancelamento,
-                            DataEnviado
+                            DataEnviado,
+                            MotivoProcessamento,
+                            DataInclusao
                         FROM Inf_InfracaoNaoTransmitida
                         WHERE
                             (Tipo = 'veiculo' OR Tipo IS NULL)
@@ -549,12 +551,14 @@ namespace Talonario.Api.Server.InfraStructure.Repository
         {
             string sql = $@"
                 SELECT
-	                Id,
-	                AIT,
-	                JSON,
-	                Tipo,
-	                DataCancelamento,
-	                DataEnviado
+                        Id,
+                        AIT,
+                        JSON,
+                        Tipo,
+                        DataCancelamento,
+                        DataEnviado,
+                        MotivoProcessamento,
+                        DataInclusao
                 FROM Inf_InfracaoNaoTransmitida
                 WHERE JSON_VALUE(JSON,'$.veiculoChassi') IS NOT NULL
                 AND JSON_VALUE(JSON,'$.veiculoPlaca') = ''
@@ -570,12 +574,14 @@ namespace Talonario.Api.Server.InfraStructure.Repository
         {
             string sql = $@"
                 SELECT
-	                Id,
-	                AIT,
-	                JSON,
-	                Tipo,
-	                DataCancelamento,
-	                DataEnviado
+                        Id,
+                        AIT,
+                        JSON,
+                        Tipo,
+                        DataCancelamento,
+                        DataEnviado,
+                        MotivoProcessamento,
+                        DataInclusao
                 FROM Inf_InfracaoNaoTransmitida
                 WHERE JSON_VALUE(JSON,'$.veiculoChassi') IS NOT NULL
                 AND JSON_VALUE(JSON,'$.veiculoPlaca') = ''
@@ -596,7 +602,9 @@ namespace Talonario.Api.Server.InfraStructure.Repository
                 JSON,
                 Tipo,
                 DataCancelamento,
-                DataEnviado
+                DataEnviado,
+                MotivoProcessamento,
+                DataInclusao
             FROM Inf_InfracaoNaoTransmitida
             WHERE Tipo = 'pedestre'
             ORDER BY Id DESC";
@@ -640,18 +648,30 @@ namespace Talonario.Api.Server.InfraStructure.Repository
             return result > 0;
         }
 
-        public async Task<bool> RemoverInfracaoNaoTransmitidaPorAIT(string ait)
+        public async Task<int> AtualizarInfracaoNaoTransmitidaAsync(InfracaoNaoTransmitidaViewModel infracaoNaoTransmitida)
         {
             string sql = $@"
-            DELETE FROM Inf_InfracaoNaoTransmitida
+            UPDATE Inf_InfracaoNaoTransmitida
+            SET JSON = @JSON,
+                Tipo = @Tipo,
+                DataCancelamento = @DataCancelamento,
+                DataEnviado = @DataEnviado,
+                MotivoProcessamento = @MotivoProcessamento,
+                DataInclusao = @DataInclusao
             WHERE AIT = @AIT";
 
             var result = await _connection.ExecuteAsync(sql, new
             {
-                AIT = ait,
+                AIT = infracaoNaoTransmitida.AIT,
+                JSON = infracaoNaoTransmitida.JSON,
+                Tipo = infracaoNaoTransmitida.Tipo?.Trim().ToLower(),
+                DataCancelamento = infracaoNaoTransmitida.DataCancelamento,
+                DataEnviado = infracaoNaoTransmitida.DataEnviado,
+                MotivoProcessamento = infracaoNaoTransmitida.MotivoProcessamento,
+                DataInclusao = infracaoNaoTransmitida.DataInclusao ?? DateTime.Now
             });
 
-            return result > 0;
+            return result;
         }
 
         public async Task<bool> RemoverInfracaoPdf(string ait)


### PR DESCRIPTION
## Summary
- substituir a remoção de infrações não transmitidas por uma atualização que mantém os dados sincronizados com o AIT
- estender entidades e mapeadores para lidar com motivo de processamento e data de inclusão
- ajustar o serviço de aplicação para realizar update ou insert conforme o retorno do repositório e adicionar testes de unidade cobrindo ambos os caminhos

## Testing
- dotnet test *(fails: comando `dotnet` indisponível no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d1dc87b483269c34378437c4f7a8