### PR TITLE
Restore recent-send filter for non-transmitted AITs

### DIFF
--- a/src/Talonario.Api.Server.InfraStructure/Repository/InfracaoRepository.cs
+++ b/src/Talonario.Api.Server.InfraStructure/Repository/InfracaoRepository.cs
@@ -535,10 +535,7 @@ namespace Talonario.Api.Server.InfraStructure.Repository
                             AND DataCancelamento IS NULL
                             AND (
                                 DataEnviado >= DATEADD(DAY, -1, GETDATE())
-                                OR (
-                                    DataEnviado IS NULL
-                                    AND TRY_CAST(JSON_VALUE(JSON, '$.dataAplicacao') AS DATETIME2) >= DATEADD(DAY, -5, GETDATE())
-                                )
+                                OR DataEnviado IS NULL
                             )
                         ORDER BY Id DESC;";
 


### PR DESCRIPTION
## Summary
- require non-transmitted vehicle AITs to have been sent within the past 24 hours when a send timestamp exists
- keep all other records regardless of application date by removing the application date window

## Testing
- not run (environment lacks dotnet runtime)


------
https://chatgpt.com/codex/tasks/task_e_68d5d33c28648326b720686c59b18803