### PR TITLE
Handle missing Recibo de Retenção signature date

### DIFF
--- a/src/Talonario.Api.Server.Application/TamaService .cs
+++ b/src/Talonario.Api.Server.Application/TamaService .cs
@@ -123,6 +123,18 @@ public class TamaService : ITamaService
     {
         var recibo = input.ReciboRetencao ?? new ReciboRetencaoViewModel();
 
+        var dataAssinaturaRecibo = recibo.DataAssinatura.HasValue && recibo.DataAssinatura.Value != default
+            ? recibo.DataAssinatura
+            : null;
+
+        var dataAssinaturaInput = input.DataAssinatura.HasValue && input.DataAssinatura.Value != default
+            ? input.DataAssinatura
+            : null;
+
+        var dataAssinaturaFinal = dataAssinaturaRecibo
+            ?? dataAssinaturaInput
+            ?? input.DataAplicacao;
+
         var viewModel = new TamaViewModel
         {
             NumeroTAMA = input.Id,
@@ -170,7 +182,7 @@ public class TamaService : ITamaService
             MatriculaAgente = input.AplicadoPorMatricula,
             UsuarioInclusao = input.AplicadoPor,
             DataHoraInclusao = input.DataAplicacao,
-            DataHoraAssinou = recibo.DataAssinatura != default ? recibo.DataAssinatura : input.DataAssinatura,
+            DataHoraAssinou = dataAssinaturaFinal,
             MatriculaAssinou = !string.IsNullOrEmpty(recibo.MatriculaAgenteAssinante)
             ? recibo.MatriculaAgenteAssinante
             : input.AplicadoPorMatricula,

--- a/src/Talonario.Api.Server.Application/ViewModels/TamaViewModel.cs
+++ b/src/Talonario.Api.Server.Application/ViewModels/TamaViewModel.cs
@@ -171,7 +171,7 @@ namespace Talonario.Api.Server.Application.ViewModels
         public DateTime DataAplicacao { get; set; }
         public string Observacoes { get; set; }
         public string Assinatura { get; set; }
-        public DateTime DataAssinatura { get; set; }
+        public DateTime? DataAssinatura { get; set; }
         public string NomeAssinante { get; set; }
         public string IdAssinante { get; set; }
         public string CpfAssinante { get; set; }
@@ -208,7 +208,7 @@ namespace Talonario.Api.Server.Application.ViewModels
         public string CondutorCPF { get; set; }
         public string CondutorNome { get; set; }
         public string CondutorCNH { get; set; }
-        public DateTime DataAssinatura { get; set; }
+        public DateTime? DataAssinatura { get; set; }
         public string AssinaturaAgente { get; set; }
         public string NomeAgenteAssinante { get; set; }
         public string MatriculaAgenteAssinante { get; set; }


### PR DESCRIPTION
## Summary
- allow nullable signature timestamps on TAMA input and Recibo de Retenção view models
- compute the signature timestamp with fallbacks when mapping to the TAMA entity so PDF generation no longer fails when the mobile payload omits the field

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d699cc14888326aec6eceae0f6f3d6