### PR TITLE
Allow null proprietor dates in TAMA input

### DIFF
--- a/src/Talonario.Api.Server.Application/ViewModels/TamaViewModel.cs
+++ b/src/Talonario.Api.Server.Application/ViewModels/TamaViewModel.cs
@@ -135,12 +135,12 @@ namespace Talonario.Api.Server.Application.ViewModels
         public string EquipamentoConsiderado { get; set; }
 
         public string ProprietarioCNHCategoria { get; set; }
-        public DateTime ProprietarioCNHValidade { get; set; }
+        public DateTime? ProprietarioCNHValidade { get; set; }
         public string ProprietarioCNHEstado { get; set; }
         public int ProprietarioDocumentoTipo { get; set; }
         public string ProprietarioDocumentoNome { get; set; }
         public string ProprietarioNDocumento { get; set; }
-        public DateTime ProprietarioDataNascimento { get; set; }
+        public DateTime? ProprietarioDataNascimento { get; set; }
         public string ProprietarioNome { get; set; }
         public string ProprietarioNomePai { get; set; }
         public string ProprietarioNomeMae { get; set; }


### PR DESCRIPTION
## Summary
- make the proprietor CNH validity and birth date optional in `TamaInputCompletoViewModel`
- prevent DateTime conversion errors when retention receipt data omits those fields

## Testing
- not run (dotnet SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9498b79148326ae07e0abf772f6e7